### PR TITLE
loading partial tss config via loader options.

### DIFF
--- a/tss/cnfgs.go
+++ b/tss/cnfgs.go
@@ -19,48 +19,124 @@ import (
 	"github.com/xlabs/tss-lib/v2/tss/internal"
 )
 
-func (s *GuardianStorage) unmarshalFromJSON(storageData []byte) error {
-	if err := json.Unmarshal(storageData, &s); err != nil {
+// StorageLoader is a helper struct to load GuardianStorage from file.
+// It allows configuring whether missing TSS secrets are allowed.
+type StorageLoader struct {
+	Path string
+
+	AllowMissingECDSA bool
+	AllowMissingFrost bool
+
+	// Allows
+	AllowNilTSSSecrets bool
+
+	// The GuardianStorage to load into. is set by the loading functions.
+	gs *GuardianStorage
+}
+
+// Default loader that does not allow missing TSS secrets.
+// for a more configurable loader, use LoadGuardianStorage.
+func NewGuardianStorageFromFile(storagePath string) (*GuardianStorage, error) {
+	loader := StorageLoader{
+		Path: storagePath,
+		gs:   &GuardianStorage{},
+
+		// not allowing missing TSS secrets by default.
+		AllowNilTSSSecrets: false,
+		AllowMissingECDSA:  false,
+		AllowMissingFrost:  false,
+	}
+
+	if err := loader.load(); err != nil {
+		return nil, err
+	}
+
+	return loader.gs, nil
+}
+
+// LoadGuardianStorage loads GuardianStorage from file using the provided StorageLoader.
+func LoadGuardianStorage(loader StorageLoader) (*GuardianStorage, error) {
+	if err := loader.load(); err != nil {
+		return nil, err
+	}
+
+	return loader.gs, nil
+}
+
+func (s *StorageLoader) load() error {
+	if s == nil {
+		return fmt.Errorf("GuardianStorage is nil")
+	}
+	if s.gs == nil {
+		s.gs = &GuardianStorage{}
+	}
+
+	storageData, err := os.ReadFile(s.Path)
+	if err != nil {
 		return err
 	}
 
-	if s.PrivateKey == nil {
+	if err := s.unmarshalFromJSON(storageData); err != nil {
+		return err
+	}
+
+	return s.gs.SetInnerFields()
+}
+
+func (s *StorageLoader) unmarshalFromJSON(storageData []byte) error {
+	if err := json.Unmarshal(storageData, &s.gs); err != nil {
+		return err
+	}
+
+	if s.gs.PrivateKey == nil {
 		return fmt.Errorf("TlsPrivateKey is nil")
 	}
 
-	if len(s.IdentitiesKeep.Identities) == 0 {
+	if len(s.gs.IdentitiesKeep.Identities) == 0 {
 		return fmt.Errorf("no guardians array given")
 	}
 
-	if s.Threshold > len(s.IdentitiesKeep.Identities) {
+	if s.gs.Threshold > len(s.gs.IdentitiesKeep.Identities) {
 		return fmt.Errorf("threshold is higher than the number of guardians")
 	}
 
 	return s.attemptLoadTssSecrets()
 }
 
-func (s *GuardianStorage) attemptLoadTssSecrets() error {
-	if s.TSSSecrets == nil {
+func (s *StorageLoader) attemptLoadTssSecrets() error {
+	if s.gs.TSSSecrets == nil {
+		if !s.AllowNilTSSSecrets {
+			return fmt.Errorf("missing TSSSecrets")
+		}
+
 		return nil
 	}
 
-	cnf, err := UnmarshalTssSecrets(s.TSSSecrets)
+	cnf, err := UnmarshalTssSecrets(s.gs.TSSSecrets)
 	if err != nil {
 		return err
 	}
 
 	if err := s.storeFrostConf(cnf); err != nil {
-		return err
+		if !s.AllowMissingFrost {
+			return err
+		}
+
+		s.gs.frostconf = nil
 	}
 
 	if err := s.storeCmpConf(cnf); err != nil {
-		return err
+		if !s.AllowMissingECDSA {
+			return err
+		}
+
+		s.gs.ecdsaconf = nil
 	}
 
 	return nil
 }
 
-func (st *GuardianStorage) storeCmpConf(cnf *party.TSSSecrets) error {
+func (st *StorageLoader) storeCmpConf(cnf *party.TSSSecrets) error {
 	if cnf == nil {
 		return fmt.Errorf("TSSSecrets is nil")
 	}
@@ -70,12 +146,12 @@ func (st *GuardianStorage) storeCmpConf(cnf *party.TSSSecrets) error {
 		return fmt.Errorf("invalid ecdsa configs in stored TSSSecrets")
 	}
 
-	st.ecdsaconf = cnf.EcdsaConfigs
+	st.gs.ecdsaconf = cnf.EcdsaConfigs
 
 	return nil
 }
 
-func (s *GuardianStorage) storeFrostConf(cnf *party.TSSSecrets) error {
+func (s *StorageLoader) storeFrostConf(cnf *party.TSSSecrets) error {
 	if cnf == nil {
 		return fmt.Errorf("TSSSecrets is nil")
 	}
@@ -85,11 +161,11 @@ func (s *GuardianStorage) storeFrostConf(cnf *party.TSSSecrets) error {
 		return fmt.Errorf("invalid frost configs in stored TSSSecrets")
 	}
 
-	if len(cnf.FrostConfigs.VerificationShares.Points) != len(s.IdentitiesKeep.Identities) {
+	if len(cnf.FrostConfigs.VerificationShares.Points) != len(s.gs.IdentitiesKeep.Identities) {
 		return fmt.Errorf("number of verification shares does not match number of guardians")
 	}
 
-	s.frostconf = cnf.FrostConfigs
+	s.gs.frostconf = cnf.FrostConfigs
 
 	return nil
 }
@@ -106,23 +182,6 @@ func UnmarshalTssSecrets(TSSsecrets []byte) (*party.TSSSecrets, error) {
 	}
 
 	return cnf, nil
-}
-
-func (s *GuardianStorage) load(storagePath string) error {
-	if s == nil {
-		return fmt.Errorf("GuardianStorage is nil")
-	}
-
-	storageData, err := os.ReadFile(storagePath)
-	if err != nil {
-		return err
-	}
-
-	if err := s.unmarshalFromJSON(storageData); err != nil {
-		return err
-	}
-
-	return s.SetInnerFields()
 }
 
 func (s *GuardianStorage) SetInnerFields() error {

--- a/tss/cnfgs.go
+++ b/tss/cnfgs.go
@@ -24,11 +24,9 @@ import (
 type StorageLoader struct {
 	Path string
 
+	// Whether to allow loading GuardianStorage with nil TSSSecrets.
 	AllowMissingECDSA bool
 	AllowMissingFrost bool
-
-	// Allows
-	AllowNilTSSSecrets bool
 
 	// The GuardianStorage to load into. is set by the loading functions.
 	gs *GuardianStorage
@@ -42,9 +40,8 @@ func NewGuardianStorageFromFile(storagePath string) (*GuardianStorage, error) {
 		gs:   &GuardianStorage{},
 
 		// not allowing missing TSS secrets by default.
-		AllowNilTSSSecrets: false,
-		AllowMissingECDSA:  false,
-		AllowMissingFrost:  false,
+		AllowMissingECDSA: false,
+		AllowMissingFrost: false,
 	}
 
 	if err := loader.load(); err != nil {
@@ -105,11 +102,7 @@ func (s *StorageLoader) unmarshalFromJSON(storageData []byte) error {
 
 func (s *StorageLoader) attemptLoadTssSecrets() error {
 	if s.gs.TSSSecrets == nil {
-		if !s.AllowNilTSSSecrets {
-			return fmt.Errorf("missing TSSSecrets")
-		}
-
-		return nil
+		return fmt.Errorf("missing TSSSecrets")
 	}
 
 	cnf, err := UnmarshalTssSecrets(s.gs.TSSSecrets)

--- a/tss/implementation.go
+++ b/tss/implementation.go
@@ -104,17 +104,6 @@ type GuardianStorage struct {
 	isleader bool
 }
 
-// GuardianStorageFromFile loads a guardian storage from a file.
-// If the storage file hadn't contained symetric keys, it'll compute them.
-func NewGuardianStorageFromFile(storagePath string) (*GuardianStorage, error) {
-	var storage GuardianStorage
-	if err := storage.load(storagePath); err != nil {
-		return nil, err
-	}
-
-	return &storage, nil
-}
-
 // Responses lets a listener receive the output signatures once they're ready.
 func (t *Engine) Responses() <-chan *signer.SignResponse {
 	return t.signResponseChan

--- a/tss/internal/cmd/dkg/server.go
+++ b/tss/internal/cmd/dkg/server.go
@@ -175,8 +175,14 @@ func attemptMergingTssSecretsToOld(lg *zap.Logger, prms runParams, tssConfigs *p
 	if prms.existingPath == "" {
 		return nil // not an error, just nothing to do
 	}
+
 	lg.Info("loading existing GuardianStorage from file", zap.String("file", *existingPath))
-	tmp, err := engine.NewGuardianStorageFromFile(*existingPath)
+	tmp, err := engine.LoadGuardianStorage(engine.StorageLoader{
+		Path:               *existingPath,
+		AllowMissingECDSA:  prms.prot == common.ProtocolECDSADKG, // if we are doing ECDSA DKG, allow missing ECDSA keys
+		AllowMissingFrost:  prms.prot == common.ProtocolFROSTDKG, // if we are doing FROST DKG, allow missing FROST keys
+		AllowNilTSSSecrets: false,                                // we need an existing TSSSecrets to merge
+	})
 	if err != nil {
 		return err
 	}

--- a/tss/internal/cmd/dkg/server.go
+++ b/tss/internal/cmd/dkg/server.go
@@ -178,10 +178,9 @@ func attemptMergingTssSecretsToOld(lg *zap.Logger, prms runParams, tssConfigs *p
 
 	lg.Info("loading existing GuardianStorage from file", zap.String("file", *existingPath))
 	tmp, err := engine.LoadGuardianStorage(engine.StorageLoader{
-		Path:               *existingPath,
-		AllowMissingECDSA:  prms.prot == common.ProtocolECDSADKG, // if we are doing ECDSA DKG, allow missing ECDSA keys
-		AllowMissingFrost:  prms.prot == common.ProtocolFROSTDKG, // if we are doing FROST DKG, allow missing FROST keys
-		AllowNilTSSSecrets: false,                                // we need an existing TSSSecrets to merge
+		Path:              *existingPath,
+		AllowMissingECDSA: prms.prot == common.ProtocolECDSADKG, // if we are doing ECDSA DKG, allow missing ECDSA keys
+		AllowMissingFrost: prms.prot == common.ProtocolFROSTDKG, // if we are doing FROST DKG, allow missing FROST keys
 	})
 	if err != nil {
 		return err

--- a/tss/setup_test.go
+++ b/tss/setup_test.go
@@ -13,11 +13,10 @@ const (
 
 func TestGuardianStorageUnmarshal(t *testing.T) {
 	loader := StorageLoader{
-		Path:               testutils.MustGetMockGuardianTssStorage(),
-		gs:                 &GuardianStorage{},
-		AllowMissingECDSA:  false,
-		AllowMissingFrost:  false,
-		AllowNilTSSSecrets: false,
+		Path:              testutils.MustGetMockGuardianTssStorage(),
+		gs:                &GuardianStorage{},
+		AllowMissingECDSA: false,
+		AllowMissingFrost: false,
 	}
 
 	if err := loader.load(); err != nil {

--- a/tss/setup_test.go
+++ b/tss/setup_test.go
@@ -12,9 +12,15 @@ const (
 )
 
 func TestGuardianStorageUnmarshal(t *testing.T) {
-	var st GuardianStorage
-	err := st.load(testutils.MustGetMockGuardianTssStorage())
-	if err != nil {
+	loader := StorageLoader{
+		Path:               testutils.MustGetMockGuardianTssStorage(),
+		gs:                 &GuardianStorage{},
+		AllowMissingECDSA:  false,
+		AllowMissingFrost:  false,
+		AllowNilTSSSecrets: false,
+	}
+
+	if err := loader.load(); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
Fixed issue with loading partial configs, as used in the DKG. 