### PR TITLE
Cnfg usage

### DIFF
--- a/service/main.go
+++ b/service/main.go
@@ -69,10 +69,22 @@ func runMain(p runParams) {
 
 	p.logger.Info("Loading secrets...")
 
-	st, err := tss.NewGuardianStorageFromFile(p.secrets)
+	st, err := tss.LoadGuardianStorage(tss.StorageLoader{
+		Path: p.secrets,
+		// allowing to load with at least one TSS scheme present, but not demanding all of them.
+		DemandAllSecrets: false,
+	})
 	if err != nil {
 		p.logger.Fatal("failed to load secrets file", zap.Error(err))
 	}
+
+	tmp := st.ExistingSecretsTypes()
+	types := make([]string, 0, len(tmp))
+	for _, t := range tmp {
+		types = append(types, t.ToString())
+	}
+
+	p.logger.Info("Loaded secrets, starting server...", zap.Strings("loaded_schemes", types))
 
 	p.logger.Info("starting TSS engine...")
 	engine, err := tss.NewReliableTSS(st)

--- a/service/main.go
+++ b/service/main.go
@@ -71,8 +71,6 @@ func runMain(p runParams) {
 
 	st, err := tss.LoadGuardianStorage(tss.StorageLoader{
 		Path: p.secrets,
-		// allowing to load with at least one TSS scheme present, but not demanding all of them.
-		DemandAllSecrets: false,
 	})
 	if err != nil {
 		p.logger.Fatal("failed to load secrets file", zap.Error(err))

--- a/service/server_conn_test.go
+++ b/service/server_conn_test.go
@@ -32,9 +32,9 @@ func TestSecureConn(t *testing.T) {
 
 	secretsDir := path.Join(getProjectRootDir(), "tss", "internal", "testutils", "testdata", "tss5")
 
-	serverSecrets, err := tss.NewGuardianStorageFromFile(path.Join(secretsDir, "guardian0.json"))
+	serverSecrets, err := tss.LoadGuardianStorage(tss.StorageLoader{Path: path.Join(secretsDir, "guardian0.json")})
 	a.NoError(err)
-	invalidSecrets, err := tss.NewGuardianStorageFromFile(path.Join(secretsDir, "guardian1.json"))
+	invalidSecrets, err := tss.LoadGuardianStorage(tss.StorageLoader{Path: path.Join(secretsDir, "guardian1.json")})
 	a.NoError(err)
 
 	pool := x509.NewCertPool()

--- a/tss/cnfgs.go
+++ b/tss/cnfgs.go
@@ -23,12 +23,10 @@ import (
 type StorageLoader struct {
 	Path string
 
-	// DemandAllSecrets indicates whether all TSS secrets must be present.
-	DemandAllSecrets bool
-
-	// DemandFrost indicates whether FROST secrets must be present.
+	// Used to demand a specific TSS scheme's secrets (or both).
+	// Even if no demand exists, if no TSS secrets are found, an error is returned.
+	// If both are false, then any existing TSS secrets is sufficient.
 	DemandFrost bool
-	// DemandECDSA indicates whether ECDSA secrets must be present.
 	DemandECDSA bool
 
 	// The GuardianStorage to load into. is set by the loading functions.
@@ -70,10 +68,6 @@ func (s *StorageLoader) load() error {
 	if s.gs == nil {
 		s.gs = &GuardianStorage{}
 	}
-	if s.DemandAllSecrets {
-		s.DemandFrost = true
-		s.DemandECDSA = true
-	}
 
 	storageData, err := internal.ReadFileWithLimit(s.Path, maxConfigFileSize)
 	if err != nil {
@@ -88,14 +82,8 @@ func (s *StorageLoader) load() error {
 		return err
 	}
 
-	if s.DemandAllSecrets {
-		// assumes all wanted secrets are loaded correctly, otherwise error would have been returned earlier.
-		return nil
-	}
-
-	// Check that at least one secret is present.
 	if s.gs.frostconf == nil && s.gs.ecdsaconf == nil {
-		return fmt.Errorf("no TSS secrets found in GuardianStorage")
+		return fmt.Errorf("no TSS secrets found in storage")
 	}
 
 	return nil

--- a/tss/cnfgs.go
+++ b/tss/cnfgs.go
@@ -23,9 +23,13 @@ import (
 type StorageLoader struct {
 	Path string
 
-	// Whether to allow loading GuardianStorage with nil TSSSecrets.
-	AllowMissingECDSA bool
-	AllowMissingFrost bool
+	// DemandAllSecrets indicates whether all TSS secrets must be present.
+	DemandAllSecrets bool
+
+	// DemandFrost indicates whether FROST secrets must be present.
+	DemandFrost bool
+	// DemandECDSA indicates whether ECDSA secrets must be present.
+	DemandECDSA bool
 
 	// The GuardianStorage to load into. is set by the loading functions.
 	gs *GuardianStorage
@@ -39,8 +43,8 @@ func NewGuardianStorageFromFile(storagePath string) (*GuardianStorage, error) {
 		gs:   &GuardianStorage{},
 
 		// not allowing missing TSS secrets by default.
-		AllowMissingECDSA: false,
-		AllowMissingFrost: false,
+		DemandFrost: true,
+		DemandECDSA: true,
 	}
 
 	if err := loader.load(); err != nil {
@@ -66,6 +70,10 @@ func (s *StorageLoader) load() error {
 	if s.gs == nil {
 		s.gs = &GuardianStorage{}
 	}
+	if s.DemandAllSecrets {
+		s.DemandFrost = true
+		s.DemandECDSA = true
+	}
 
 	storageData, err := internal.ReadFileWithLimit(s.Path, maxConfigFileSize)
 	if err != nil {
@@ -76,7 +84,21 @@ func (s *StorageLoader) load() error {
 		return err
 	}
 
-	return s.gs.SetInnerFields()
+	if err := s.gs.SetInnerFields(); err != nil {
+		return err
+	}
+
+	if s.DemandAllSecrets {
+		// assumes all wanted secrets are loaded correctly, otherwise error would have been returned earlier.
+		return nil
+	}
+
+	// Check that at least one secret is present.
+	if s.gs.frostconf == nil && s.gs.ecdsaconf == nil {
+		return fmt.Errorf("no TSS secrets found in GuardianStorage")
+	}
+
+	return nil
 }
 
 func (s *StorageLoader) unmarshalFromJSON(storageData []byte) error {
@@ -110,7 +132,7 @@ func (s *StorageLoader) attemptLoadTssSecrets() error {
 	}
 
 	if err := s.storeFrostConf(cnf); err != nil {
-		if !s.AllowMissingFrost {
+		if s.DemandFrost {
 			return err
 		}
 
@@ -118,7 +140,7 @@ func (s *StorageLoader) attemptLoadTssSecrets() error {
 	}
 
 	if err := s.storeCmpConf(cnf); err != nil {
-		if !s.AllowMissingECDSA {
+		if s.DemandECDSA {
 			return err
 		}
 
@@ -311,4 +333,18 @@ func (s *GuardianStorage) NumGuardians() int {
 	}
 
 	return len(s.Identities)
+}
+
+func (s *GuardianStorage) ExistingSecretsTypes() []common.ProtocolType {
+	types := []common.ProtocolType{}
+
+	if s.frostconf != nil {
+		types = append(types, common.ProtocolFROSTDKG)
+	}
+
+	if s.ecdsaconf != nil {
+		types = append(types, common.ProtocolECDSADKG)
+	}
+
+	return types
 }

--- a/tss/cnfgs.go
+++ b/tss/cnfgs.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/fxamacker/cbor/v2"
@@ -68,7 +67,7 @@ func (s *StorageLoader) load() error {
 		s.gs = &GuardianStorage{}
 	}
 
-	storageData, err := os.ReadFile(s.Path)
+	storageData, err := internal.ReadFileWithLimit(s.Path, maxConfigFileSize)
 	if err != nil {
 		return err
 	}

--- a/tss/cnfgs.go
+++ b/tss/cnfgs.go
@@ -33,25 +33,6 @@ type StorageLoader struct {
 	gs *GuardianStorage
 }
 
-// Default loader that does not allow missing TSS secrets.
-// for a more configurable loader, use LoadGuardianStorage.
-func NewGuardianStorageFromFile(storagePath string) (*GuardianStorage, error) {
-	loader := StorageLoader{
-		Path: storagePath,
-		gs:   &GuardianStorage{},
-
-		// not allowing missing TSS secrets by default.
-		DemandFrost: true,
-		DemandECDSA: true,
-	}
-
-	if err := loader.load(); err != nil {
-		return nil, err
-	}
-
-	return loader.gs, nil
-}
-
 // LoadGuardianStorage loads GuardianStorage from file using the provided StorageLoader.
 func LoadGuardianStorage(loader StorageLoader) (*GuardianStorage, error) {
 	if err := loader.load(); err != nil {

--- a/tss/cnfgs_test.go
+++ b/tss/cnfgs_test.go
@@ -1,0 +1,233 @@
+package tss
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	common "github.com/xlabs/tss-common"
+)
+
+func generateTestKeys(t *testing.T) ([]byte, []byte, []byte) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPem := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privBytes})
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubPem := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes})
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+
+	return privPem, pubPem, certPem
+}
+
+func TestLoadGuardianStorage(t *testing.T) {
+	privPem, pubPem, certPem := generateTestKeys(t)
+
+	pid := &common.PartyID{ID: "party1"}
+
+	id := &Identity{
+		KeyPEM:   pubPem,
+		CertPem:  certPem,
+		Pid:      pid,
+		Hostname: "localhost:8080",
+	}
+
+	// Construct a valid GuardianStorage
+	// We populate both Identities and IdentitiesKeep to ensure compatibility with the loading logic
+	gs := &GuardianStorage{
+		PrivateKey: privPem,
+		Self:       id,
+		IdentitiesKeep: IdentitiesKeep{
+			Identities: []*Identity{id},
+		},
+		Threshold: 1,
+		TlsX509:   certPem,
+	}
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "storage.json")
+
+	writeMockGuardianStorage(t, gs, path)
+
+	t.Run("Fail missing secrets", func(t *testing.T) {
+		loader := StorageLoader{
+			Path:             path,
+			DemandAllSecrets: true,
+		}
+		_, err := LoadGuardianStorage(loader)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "missing TSSSecrets") {
+			t.Errorf("expected error to contain 'missing TSSSecrets', got %v", err)
+		}
+	})
+
+	t.Run("Fail invalid JSON", func(t *testing.T) {
+		badPath := filepath.Join(tmpDir, "bad.json")
+		os.WriteFile(badPath, []byte("{invalid"), 0600)
+		loader := StorageLoader{Path: badPath}
+		_, err := LoadGuardianStorage(loader)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("Fail file not found", func(t *testing.T) {
+		loader := StorageLoader{Path: filepath.Join(tmpDir, "missing.json")}
+		_, err := LoadGuardianStorage(loader)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestNewGuardianStorageFromFile(t *testing.T) {
+	// This function enforces DemandFrost=true and DemandECDSA=true
+	// Since we don't have valid secrets in the file, we expect it to fail.
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "storage.json")
+
+	// Create a dummy file (valid JSON structure but missing secrets)
+	privPem, pubPem, certPem := generateTestKeys(t)
+	id := &Identity{
+		KeyPEM:   pubPem,
+		CertPem:  certPem,
+		Pid:      &common.PartyID{ID: "p1"},
+		Hostname: "h",
+	}
+	gs := &GuardianStorage{
+		PrivateKey:     privPem,
+		Self:           id,
+		IdentitiesKeep: IdentitiesKeep{Identities: []*Identity{id}},
+		Threshold:      1,
+		TlsX509:        certPem,
+	}
+
+	writeMockGuardianStorage(t, gs, path)
+
+	_, err := NewGuardianStorageFromFile(path)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing TSSSecrets") {
+		t.Errorf("expected error to contain 'missing TSSSecrets', got %v", err)
+	}
+}
+
+func TestUnmarshalTssSecrets(t *testing.T) {
+	_, err := UnmarshalTssSecrets([]byte("invalid cbor"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestLoadGuardianStorage_WithSecrets(t *testing.T) {
+	gs := loadMockGuardianStorage(0, "tss5")
+
+	// corrupt frost secrets to simulate missing frost configs
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "storage_secrets.json")
+
+	t.Run("missing frost secrets allowed", func(t *testing.T) {
+		secretsAsString := string(gs.TSSSecrets)
+		// corrupt frost configs so CBOR unmarshal fails
+		gs.TSSSecrets = []byte(strings.Replace(secretsAsString, "FrostConfigs", "fr0stc0nf!gs", 1))
+		defer func() { gs.TSSSecrets = []byte(secretsAsString) }() // restore
+
+		writeMockGuardianStorage(t, gs, path)
+
+		_, err := LoadGuardianStorage(StorageLoader{
+			Path:             path,
+			DemandAllSecrets: false,
+			DemandECDSA:      true,
+			DemandFrost:      false,
+		})
+		if err != nil {
+			t.Fatal("expected no error, got:", err)
+		}
+	})
+
+	t.Run("missing ecdsa secrets allowed", func(t *testing.T) {
+		secretsAsString := string(gs.TSSSecrets)
+		// corrupt ecdsa configs so CBOR unmarshal fails
+		gs.TSSSecrets = []byte(strings.Replace(secretsAsString, "EcdsaConfigs", "3cds4c0nf!gs", 1))
+		defer func() { gs.TSSSecrets = []byte(secretsAsString) }() // restore
+
+		writeMockGuardianStorage(t, gs, path)
+
+		if _, err := LoadGuardianStorage(StorageLoader{
+			Path:             path,
+			DemandAllSecrets: false,
+			DemandECDSA:      false,
+			DemandFrost:      true,
+		}); err != nil {
+			t.Fatal("expected no error, got:", err)
+		}
+
+		if _, err := LoadGuardianStorage(StorageLoader{
+			Path:             path,
+			DemandAllSecrets: false,
+			DemandECDSA:      true,
+			DemandFrost:      false,
+		}); err == nil {
+			t.Fatal("expected error")
+		}
+
+		if _, err := LoadGuardianStorage(StorageLoader{
+			Path:             path,
+			DemandAllSecrets: true,
+			DemandECDSA:      false,
+			DemandFrost:      false,
+		}); err == nil {
+			t.Fatal("expected missing ecdsa error")
+		}
+	})
+}
+
+func writeMockGuardianStorage(t *testing.T, gs *GuardianStorage, path string) {
+	data, err := json.Marshal(gs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tss/cnfgs_test.go
+++ b/tss/cnfgs_test.go
@@ -141,7 +141,7 @@ func TestNewGuardianStorageFromFile(t *testing.T) {
 
 	writeMockGuardianStorage(t, gs, path)
 
-	_, err := NewGuardianStorageFromFile(path)
+	_, err := LoadGuardianStorage(StorageLoader{Path: path, DemandECDSA: true, DemandFrost: true})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/tss/cnfgs_test.go
+++ b/tss/cnfgs_test.go
@@ -214,8 +214,6 @@ func TestLoadGuardianStorage_WithSecrets(t *testing.T) {
 		if _, err := LoadGuardianStorage(StorageLoader{
 			Path:             path,
 			DemandAllSecrets: true,
-			DemandECDSA:      false,
-			DemandFrost:      false,
 		}); err == nil {
 			t.Fatal("expected missing ecdsa error")
 		}

--- a/tss/cnfgs_test.go
+++ b/tss/cnfgs_test.go
@@ -86,8 +86,7 @@ func TestLoadGuardianStorage(t *testing.T) {
 
 	t.Run("Fail missing secrets", func(t *testing.T) {
 		loader := StorageLoader{
-			Path:             path,
-			DemandAllSecrets: true,
+			Path: path,
 		}
 		_, err := LoadGuardianStorage(loader)
 		if err == nil {
@@ -175,10 +174,9 @@ func TestLoadGuardianStorage_WithSecrets(t *testing.T) {
 		writeMockGuardianStorage(t, gs, path)
 
 		_, err := LoadGuardianStorage(StorageLoader{
-			Path:             path,
-			DemandAllSecrets: false,
-			DemandECDSA:      true,
-			DemandFrost:      false,
+			Path:        path,
+			DemandECDSA: true,
+			DemandFrost: false,
 		})
 		if err != nil {
 			t.Fatal("expected no error, got:", err)
@@ -194,28 +192,44 @@ func TestLoadGuardianStorage_WithSecrets(t *testing.T) {
 		writeMockGuardianStorage(t, gs, path)
 
 		if _, err := LoadGuardianStorage(StorageLoader{
-			Path:             path,
-			DemandAllSecrets: false,
-			DemandECDSA:      false,
-			DemandFrost:      true,
+			Path:        path,
+			DemandECDSA: false,
+			DemandFrost: true,
 		}); err != nil {
 			t.Fatal("expected no error, got:", err)
 		}
 
 		if _, err := LoadGuardianStorage(StorageLoader{
-			Path:             path,
-			DemandAllSecrets: false,
-			DemandECDSA:      true,
-			DemandFrost:      false,
+			Path:        path,
+			DemandECDSA: true,
+			DemandFrost: false,
 		}); err == nil {
 			t.Fatal("expected error")
 		}
 
 		if _, err := LoadGuardianStorage(StorageLoader{
-			Path:             path,
-			DemandAllSecrets: true,
-		}); err == nil {
-			t.Fatal("expected missing ecdsa error")
+			Path:        path,
+			DemandECDSA: false,
+			DemandFrost: false,
+		}); err != nil {
+			t.Fatal("no error should've occurred, got:", err)
+		}
+	})
+
+	t.Run("missing secrets not allowed", func(t *testing.T) {
+		secretsAsString := string(gs.TSSSecrets)
+		// corrupt both configs so CBOR unmarshal fails
+		gs.TSSSecrets = []byte(strings.Replace(strings.Replace(secretsAsString, "FrostConfigs", "fr0stc0nf!gs", 1), "EcdsaConfigs", "3cds4c0nf!gs", 1))
+		defer func() { gs.TSSSecrets = []byte(secretsAsString) }() // restore
+
+		writeMockGuardianStorage(t, gs, path)
+		_, err := LoadGuardianStorage(StorageLoader{
+			Path:        path,
+			DemandECDSA: false,
+			DemandFrost: false,
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 }

--- a/tss/comm/server_test.go
+++ b/tss/comm/server_test.go
@@ -465,7 +465,7 @@ func loadMockGuardianStorage(gstorageIndex int) (*tss.GuardianStorage, error) {
 		return nil, err
 	}
 
-	st, err := tss.NewGuardianStorageFromFile(path)
+	st, err := tss.LoadGuardianStorage(tss.StorageLoader{Path: path})
 	if err != nil {
 		return nil, err
 	}

--- a/tss/constants.go
+++ b/tss/constants.go
@@ -39,7 +39,8 @@ func extractProtoTypeNames(protoreflectDesc protoreflect.FileDescriptor) []strin
 }
 
 const (
-	DefaultPort = "8998"
+	maxConfigFileSize = 10 * 1024 * 1024 // 10 MB
+	DefaultPort       = "8998"
 
 	digestSize           = 32
 	maxAuxiliaryDataSize = 32

--- a/tss/implementation_test.go
+++ b/tss/implementation_test.go
@@ -1122,7 +1122,11 @@ func loadMockGuardianStorage(gstorageIndex int, from string) *GuardianStorage {
 		panic(err)
 	}
 
-	st, err := NewGuardianStorageFromFile(path)
+	st, err := LoadGuardianStorage(StorageLoader{
+		Path:        path,
+		DemandFrost: true,
+		DemandECDSA: true,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/tss/internal/certs.go
+++ b/tss/internal/certs.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	PRIVATE_KEY_TYPE = "PRIVATE KEY"
-	PUBLIC_KEY_TYPE  = "PUBLIC KEY"
-	CERTIFICATE_TYPE = "CERTIFICATE"
+	privateKeyType  = "PRIVATE KEY"
+	publicKeyType   = "PUBLIC KEY"
+	certificateType = "CERTIFICATE"
 )
 
 // CreateCert invokes x509.CreateCertificate and returns it in the x509.Certificate format
@@ -30,7 +30,7 @@ func CreateCert(template, parent *x509.Certificate, pub *ecdsa.PublicKey, parent
 		return
 	}
 	// PEM encode the certificate (this is a standard TLS encoding)
-	b := pem.Block{Type: "CERTIFICATE", Bytes: certDER}
+	b := pem.Block{Type: certificateType, Bytes: certDER}
 	certPEM = pem.EncodeToMemory(&b)
 	return
 }
@@ -58,7 +58,7 @@ func PrivateKeyToPem(pkey *ecdsa.PrivateKey) []byte {
 	}
 
 	return pem.EncodeToMemory(&pem.Block{
-		Type: PRIVATE_KEY_TYPE, Bytes: keyBytes,
+		Type: privateKeyType, Bytes: keyBytes,
 	})
 }
 
@@ -69,7 +69,7 @@ func PublicKeyToPem(pkey *ecdsa.PublicKey) ([]byte, error) {
 	}
 
 	return pem.EncodeToMemory(&pem.Block{
-		Type: PUBLIC_KEY_TYPE, Bytes: keyBytes,
+		Type: publicKeyType, Bytes: keyBytes,
 	}), nil
 }
 
@@ -78,7 +78,7 @@ func PemToPublicKey(pemBytes []byte) (*ecdsa.PublicKey, error) {
 	if block == nil {
 		return nil, errors.New("failed to decode PEM block containing the public key")
 	}
-	if block.Type != PUBLIC_KEY_TYPE {
+	if block.Type != publicKeyType {
 		return nil, errors.New("PEM block is not a public key")
 	}
 
@@ -100,7 +100,7 @@ func PemToPrivateKey(pemBytes []byte) (*ecdsa.PrivateKey, error) {
 	if block == nil {
 		return nil, errors.New("failed to decode PEM block containing the private key")
 	}
-	if block.Type != PRIVATE_KEY_TYPE {
+	if block.Type != privateKeyType {
 		return nil, errors.New("PEM block is not a private key")
 	}
 
@@ -118,7 +118,7 @@ func PemToPrivateKey(pemBytes []byte) (*ecdsa.PrivateKey, error) {
 }
 
 func CertToPem(cert *x509.Certificate) []byte {
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	return pem.EncodeToMemory(&pem.Block{Type: certificateType, Bytes: cert.Raw})
 }
 
 func PemToCert(pemBytes []byte) (*x509.Certificate, error) {
@@ -126,7 +126,7 @@ func PemToCert(pemBytes []byte) (*x509.Certificate, error) {
 	if block == nil {
 		return nil, errors.New("failed to decode PEM block containing the certificate")
 	}
-	if block.Type != "CERTIFICATE" {
+	if block.Type != certificateType {
 		return nil, errors.New("PEM block is not a certificate")
 	}
 

--- a/tss/internal/certs.go
+++ b/tss/internal/certs.go
@@ -10,6 +10,12 @@ import (
 	"log"
 )
 
+const (
+	PRIVATE_KEY_TYPE = "PRIVATE KEY"
+	PUBLIC_KEY_TYPE  = "PUBLIC KEY"
+	CERTIFICATE_TYPE = "CERTIFICATE"
+)
+
 // CreateCert invokes x509.CreateCertificate and returns it in the x509.Certificate format
 func CreateCert(template, parent *x509.Certificate, pub *ecdsa.PublicKey, parentPriv *ecdsa.PrivateKey) (
 	cert *x509.Certificate, certPEM []byte, err error) {
@@ -52,7 +58,7 @@ func PrivateKeyToPem(pkey *ecdsa.PrivateKey) []byte {
 	}
 
 	return pem.EncodeToMemory(&pem.Block{
-		Type: "PRIVATE KEY", Bytes: keyBytes,
+		Type: PRIVATE_KEY_TYPE, Bytes: keyBytes,
 	})
 }
 
@@ -63,7 +69,7 @@ func PublicKeyToPem(pkey *ecdsa.PublicKey) ([]byte, error) {
 	}
 
 	return pem.EncodeToMemory(&pem.Block{
-		Type: "PUBLIC KEY", Bytes: keyBytes,
+		Type: PUBLIC_KEY_TYPE, Bytes: keyBytes,
 	}), nil
 }
 
@@ -72,7 +78,7 @@ func PemToPublicKey(pemBytes []byte) (*ecdsa.PublicKey, error) {
 	if block == nil {
 		return nil, errors.New("failed to decode PEM block containing the public key")
 	}
-	if block.Type != "PUBLIC KEY" {
+	if block.Type != PUBLIC_KEY_TYPE {
 		return nil, errors.New("PEM block is not a public key")
 	}
 
@@ -88,12 +94,13 @@ func PemToPublicKey(pemBytes []byte) (*ecdsa.PublicKey, error) {
 
 	return publicKey, nil
 }
+
 func PemToPrivateKey(pemBytes []byte) (*ecdsa.PrivateKey, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
 		return nil, errors.New("failed to decode PEM block containing the private key")
 	}
-	if block.Type != "PRIVATE KEY" {
+	if block.Type != PRIVATE_KEY_TYPE {
 		return nil, errors.New("PEM block is not a private key")
 	}
 

--- a/tss/internal/cmd/dkg/server.go
+++ b/tss/internal/cmd/dkg/server.go
@@ -181,9 +181,10 @@ func attemptMergingTssSecretsToOld(lg *zap.Logger, prms runParams, tssConfigs *p
 
 	lg.Info("loading existing GuardianStorage from file", zap.String("file", *existingPath))
 	tmp, err := engine.LoadGuardianStorage(engine.StorageLoader{
-		Path:              *existingPath,
-		AllowMissingECDSA: prms.prot == common.ProtocolECDSADKG, // if we are doing ECDSA DKG, allow missing ECDSA keys
-		AllowMissingFrost: prms.prot == common.ProtocolFROSTDKG, // if we are doing FROST DKG, allow missing FROST keys
+		Path: *existingPath,
+
+		DemandFrost: prms.prot == common.ProtocolECDSADKG, // if we're doing ECDSA DKG, and want to merge, we assume Frost secrets must exist.
+		DemandECDSA: prms.prot == common.ProtocolFROSTDKG, // if we're doing Frost DKG, and want to merge, we assume ECDSA secrets must exist.
 	})
 	if err != nil {
 		return err

--- a/tss/internal/cmd/dkg/server.go
+++ b/tss/internal/cmd/dkg/server.go
@@ -24,10 +24,11 @@ import (
 )
 
 var (
-	cnfgPath     = flag.String("cnfg", "", "path to config file in json format used to run the protocol")
-	existingPath = flag.String("secrets", "", "path to existing secrets.json. Used to ensure the result of DKG contains any existing keys for other protocols.")
-	protocolMsg  = fmt.Sprintf("the TSS protocol type to use ( '%s' | '%s')", common.ProtocolFROSTDKG, common.ProtocolECDSADKG)
-	protocol     = flag.String("protocol", "", protocolMsg)
+	cnfgPath      = flag.String("cnfg", "", "path to config file in json format used to run the protocol")
+	secretKeyPath = flag.String("sk", "", "path to secret key file in PEM format (should match the TLS certificate in the config file)")
+	existingPath  = flag.String("secrets", "", "path to existing secrets.json. Used to ensure the result of DKG contains any existing keys for other protocols.")
+	protocolMsg   = fmt.Sprintf("the TSS protocol type to use ( '%s' | '%s')", common.ProtocolFROSTDKG, common.ProtocolECDSADKG)
+	protocol      = flag.String("protocol", "", protocolMsg)
 )
 
 var logger *zap.Logger
@@ -291,6 +292,19 @@ func loadConfigsFromFlags(logger *zap.Logger) (*cmd.SetupConfigs, common.Protoco
 
 	if err = json.Unmarshal(f, cnfg); err != nil {
 		logger.Fatal("failed to unmarshal config file", zap.Error(err))
+	}
+
+	if *secretKeyPath != "" {
+		// read file:
+		skBts, err := os.ReadFile(*secretKeyPath)
+		if err != nil {
+			logger.Fatal("failed to read secret key file", zap.Error(err))
+		}
+		cnfg.SelfSecret = skBts
+	}
+
+	if len(cnfg.SelfSecret) == 0 {
+		logger.Fatal("missing secret key. Please provide a path to the secret key, or set it in the config file.")
 	}
 
 	if *protocol != common.ProtocolECDSADKG.ToString() && *protocol != common.ProtocolFROSTDKG.ToString() {

--- a/tss/internal/cmd/dkg/server.go
+++ b/tss/internal/cmd/dkg/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"flag"
@@ -19,6 +20,7 @@ import (
 	"github.com/xlabs/tss-lib/v2/party"
 	engine "github.com/xlabs/tss-lib/v2/tss"
 	"github.com/xlabs/tss-lib/v2/tss/comm"
+	"github.com/xlabs/tss-lib/v2/tss/internal"
 	"github.com/xlabs/tss-lib/v2/tss/internal/cmd"
 	"go.uber.org/zap"
 )
@@ -283,23 +285,27 @@ func loadConfigsFromFlags(logger *zap.Logger) (*cmd.SetupConfigs, common.Protoco
 
 	logger.Info("Loading config file", zap.String("path", *cnfgPath))
 
-	f, err := os.ReadFile(*cnfgPath)
+	cnfgData, err := internal.ReadFileWithLimit(*cnfgPath, 4*1024*1024) // 4MB max
 	if err != nil {
 		logger.Fatal("failed to read file, err: ", zap.Error(err))
 	}
 
 	cnfg := &cmd.SetupConfigs{}
-
-	if err = json.Unmarshal(f, cnfg); err != nil {
+	if err = json.Unmarshal(cnfgData, cnfg); err != nil {
 		logger.Fatal("failed to unmarshal config file", zap.Error(err))
 	}
 
 	if *secretKeyPath != "" {
-		// read file:
-		skBts, err := os.ReadFile(*secretKeyPath)
+		skBts, err := internal.ReadFileWithLimit(*secretKeyPath, 1024*1024) // Assuming key size of atmost 1MB.
 		if err != nil {
 			logger.Fatal("failed to read secret key file", zap.Error(err))
 		}
+
+		// inspect cert and secret match:
+		if _, err := tls.X509KeyPair(cnfg.Self.TlsX509, skBts); err != nil {
+			logger.Fatal("issue with TLS certificate and private key pair", zap.Error(err))
+		}
+
 		cnfg.SelfSecret = skBts
 	}
 

--- a/tss/internal/cmd/dkg/server.go
+++ b/tss/internal/cmd/dkg/server.go
@@ -297,7 +297,8 @@ func loadConfigsFromFlags(logger *zap.Logger) (*cmd.SetupConfigs, common.Protoco
 	}
 
 	if *secretKeyPath != "" {
-		skBts, err := internal.ReadFileWithLimit(*secretKeyPath, 1024*1024) // Assuming key size of atmost 1MB.
+		// Assuming key size of at most 1MB.
+		skBts, err := internal.ReadFileWithLimit(*secretKeyPath, 1024*1024)
 		if err != nil {
 			logger.Fatal("failed to read secret key file", zap.Error(err))
 		}

--- a/tss/internal/cmd/scripts_test.go
+++ b/tss/internal/cmd/scripts_test.go
@@ -104,7 +104,7 @@ func TestMain(t *testing.T) {
 		forLocalDKG:               true,
 		storeIntoInternalTestData: true, // ensure we update the internal testdata after running DKG
 	}
-	// t.Run("RunDKG", tt.RunDKG)
+	t.Run("RunDKG", tt.RunDKG)
 
 	// tt = dkgTest{
 	// 	hostnames: hostnames,
@@ -375,7 +375,7 @@ func (d dkgTest) RunDKG(t *testing.T) {
 		_path := path.Join(d.saveFolder, saveLocation, "secrets.json")
 
 		//read the file into a GuardianStorage struct
-		gst, err := engine.NewGuardianStorageFromFile(_path)
+		gst, err := engine.LoadGuardianStorage(engine.StorageLoader{Path: _path})
 		if err != nil {
 			t.Fatalf("failed to read guardian storage from file: %v", err)
 		}

--- a/tss/internal/file.go
+++ b/tss/internal/file.go
@@ -1,0 +1,31 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+/*
+ReadFileWithLimit reads the file at the given path, ensuring that its
+size does not exceed maxBytes.
+*/
+func ReadFileWithLimit(path string, maxBytes int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	defer f.Close()
+
+	if stats, err := f.Stat(); err == nil && stats.Size() > maxBytes {
+		return nil, fmt.Errorf("file size exceeds limit of %d bytes", maxBytes)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/tss/internal/file.go
+++ b/tss/internal/file.go
@@ -10,7 +10,8 @@ import (
 var ErrExceedMaxFileSize = errors.New("file size exceeds maximum allowed size")
 
 // ReadFileWithLimit reads the file at the given path, ensuring that the file size does not exceed maxBytes.
-// If the file size exceeds maxBytes, an
+// If the file size exceeds maxBytes, a specific error ErrExceedMaxFileSize is returned.
+// other than that, it behaves like os.ReadFile.
 func ReadFileWithLimit(path string, maxBytes int64) ([]byte, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/tss/internal/file.go
+++ b/tss/internal/file.go
@@ -1,15 +1,16 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 )
 
-/*
-ReadFileWithLimit reads the file at the given path, ensuring that its
-size does not exceed maxBytes.
-*/
+var ErrExceedMaxFileSize = errors.New("file size exceeds maximum allowed size")
+
+// ReadFileWithLimit reads the file at the given path, ensuring that the file size does not exceed maxBytes.
+// If the file size exceeds maxBytes, an
 func ReadFileWithLimit(path string, maxBytes int64) ([]byte, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -18,13 +19,14 @@ func ReadFileWithLimit(path string, maxBytes int64) ([]byte, error) {
 
 	defer f.Close()
 
-	if stats, err := f.Stat(); err == nil && stats.Size() > maxBytes {
-		return nil, fmt.Errorf("file size exceeds limit of %d bytes", maxBytes)
-	}
-
-	data, err := io.ReadAll(io.LimitReader(f, maxBytes))
+	// Read one byte more than the limit to detect if the file exceeds the limit.
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
 	if err != nil {
 		return nil, err
+	}
+
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%w: %d > %d", ErrExceedMaxFileSize, len(data), maxBytes)
 	}
 
 	return data, nil

--- a/tss/internal/file_test.go
+++ b/tss/internal/file_test.go
@@ -1,0 +1,85 @@
+package internal
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadFileWithLimit(t *testing.T) {
+	// Create a temporary directory for test files.
+	// t.TempDir automatically cleans up after the test.
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name          string
+		content       string
+		maxBytes      int64
+		expectedData  string
+		expectedError error
+	}{
+		{
+			name:          "valid file within limit",
+			content:       "hello world",
+			maxBytes:      100,
+			expectedData:  "hello world",
+			expectedError: nil,
+		},
+		{
+			name:          "valid file exactly at limit",
+			content:       "hello",
+			maxBytes:      5,
+			expectedData:  "hello",
+			expectedError: nil,
+		},
+		{
+			name:          "file exceeds limit",
+			content:       "hello world",
+			maxBytes:      5,
+			expectedData:  "",
+			expectedError: ErrExceedMaxFileSize,
+		},
+		{
+			name:          "empty file",
+			content:       "",
+			maxBytes:      10,
+			expectedData:  "",
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filename := filepath.Join(tmpDir, tc.name)
+			// Write the test content to a file
+			if err := os.WriteFile(filename, []byte(tc.content), 0644); err != nil {
+				t.Fatalf("failed to create test file: %v", err)
+			}
+
+			got, err := ReadFileWithLimit(filename, tc.maxBytes)
+
+			if tc.expectedError != nil {
+				if !errors.Is(err, tc.expectedError) {
+					t.Errorf("expected error %v, got %v", tc.expectedError, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if string(got) != tc.expectedData {
+				t.Errorf("expected content %q, got %q", tc.expectedData, string(got))
+			}
+		})
+	}
+
+	t.Run("non-existent file", func(t *testing.T) {
+		_, err := ReadFileWithLimit(filepath.Join(tmpDir, "does-not-exist"), 10)
+		if !os.IsNotExist(err) {
+			t.Errorf("expected os.ErrNotExist, got %v", err)
+		}
+	})
+}

--- a/tss/setup_test.go
+++ b/tss/setup_test.go
@@ -13,9 +13,10 @@ const (
 
 func TestGuardianStorageUnmarshal(t *testing.T) {
 	loader := StorageLoader{
-		Path:             testutils.MustGetMockGuardianTssStorage(),
-		gs:               &GuardianStorage{},
-		DemandAllSecrets: true,
+		Path:        testutils.MustGetMockGuardianTssStorage(),
+		gs:          &GuardianStorage{},
+		DemandFrost: true,
+		DemandECDSA: true,
 	}
 
 	if err := loader.load(); err != nil {

--- a/tss/setup_test.go
+++ b/tss/setup_test.go
@@ -13,10 +13,10 @@ const (
 
 func TestGuardianStorageUnmarshal(t *testing.T) {
 	loader := StorageLoader{
-		Path:              testutils.MustGetMockGuardianTssStorage(),
-		gs:                &GuardianStorage{},
-		AllowMissingECDSA: false,
-		AllowMissingFrost: false,
+		Path:        testutils.MustGetMockGuardianTssStorage(),
+		gs:          &GuardianStorage{},
+		DemandFrost: true,
+		DemandECDSA: true,
 	}
 
 	if err := loader.load(); err != nil {

--- a/tss/setup_test.go
+++ b/tss/setup_test.go
@@ -13,10 +13,9 @@ const (
 
 func TestGuardianStorageUnmarshal(t *testing.T) {
 	loader := StorageLoader{
-		Path:        testutils.MustGetMockGuardianTssStorage(),
-		gs:          &GuardianStorage{},
-		DemandFrost: true,
-		DemandECDSA: true,
+		Path:             testutils.MustGetMockGuardianTssStorage(),
+		gs:               &GuardianStorage{},
+		DemandAllSecrets: true,
 	}
 
 	if err := loader.load(); err != nil {


### PR DESCRIPTION
Allowing DKG to load a separate secrets file, instead of loading a file containing both public data and secret data. 
In addition, allowing signer service to load with only one tss scheme, instead of all of them. 